### PR TITLE
Save the file's byte size in uploadFile function

### DIFF
--- a/controllers/fileController.js
+++ b/controllers/fileController.js
@@ -9,7 +9,7 @@ exports.uploadFile = async (req, res) => {
   try {
     const { filename } = req.body;
     const file = req.file.buffer; // The uploaded file's buffer
-    const size = req.file.size / 1048576; // file size in MB
+    const size = req.file.size;
     const user = req.user;
     const newFile = new File({
       filename,


### PR DESCRIPTION
Rather than save the file's size in MB just save the file's byte size so that it can be formatted on the frontend.